### PR TITLE
Change ResultSetMetaData # getColumnName method start index.

### DIFF
--- a/src/main/java/com/jakewharton/fliptables/FlipTableConverters.java
+++ b/src/main/java/com/jakewharton/fliptables/FlipTableConverters.java
@@ -90,7 +90,7 @@ public final class FlipTableConverters {
     ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
     int columnCount = resultSetMetaData.getColumnCount();
     for (int column = 0; column < columnCount; column++) {
-      headers.add(resultSetMetaData.getColumnName(column));
+      headers.add(resultSetMetaData.getColumnName(column + 1));
     }
 
     List<String[]> data = new ArrayList<>();

--- a/src/test/java/com/jakewharton/fliptables/util/FakeResultSet.java
+++ b/src/test/java/com/jakewharton/fliptables/util/FakeResultSet.java
@@ -35,7 +35,7 @@ public final class FakeResultSet extends AbstractResultSet {
     }
 
     @Override public String getColumnName(int column) throws SQLException {
-      return headers[column];
+      return headers[column - 1];
     }
   }
 }


### PR DESCRIPTION
Index of ResultSetMetaData # getColumnName is modification in order to start from 1.
https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSetMetaData.html#getColumnName-int-
