### PR TITLE
Fix CRLF cell rendering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ java {
   targetCompatibility = VERSION_1_8
 }
 
+tasks.withType(JavaCompile) {
+  options.encoding = 'UTF-8'
+}
+
 dependencies {
   testImplementation libs.junit
   testImplementation libs.truth

--- a/src/main/java/com/jakewharton/fliptables/FlipTable.java
+++ b/src/main/java/com/jakewharton/fliptables/FlipTable.java
@@ -56,7 +56,7 @@ public final class FlipTable {
             String.format("Row %s's %s columns != %s columns", row + 1, rowData.length, columns));
       }
       for (int column = 0; column < columns; column++) {
-        for (String rowDataLine : String.valueOf(rowData[column]).split("\\n")) {
+        for (String rowDataLine : String.valueOf(rowData[column]).split("\\R")) {
           String rowDataWithoutColor = rowDataLine.replaceAll(ANSI_COLORS, "");
           columnWidths[column] = Math.max(columnWidths[column], rowDataWithoutColor.length());
         }
@@ -104,7 +104,7 @@ public final class FlipTable {
     for (int line = 0, lines = 1; line < lines; line++) {
       for (int column = 0; column < columns; column++) {
         out.append(column == 0 ? '║' : '│');
-        String[] cellLines = String.valueOf(data[column]).split("\\n");
+        String[] cellLines = String.valueOf(data[column]).split("\\R");
         lines = Math.max(lines, cellLines.length);
         String cellLine = line < cellLines.length ? cellLines[line] : "";
         out.append(pad(columnWidths[column], cellLine));

--- a/src/test/java/com/jakewharton/fliptables/FlipTableTest.java
+++ b/src/test/java/com/jakewharton/fliptables/FlipTableTest.java
@@ -273,4 +273,24 @@ public class FlipTableTest {
       assertThat(e).hasMessageThat().isEqualTo("data[1] == null");
     }
   }
+
+  @Test public void crlfCellRendersIdenticallyToLfCell() {
+    String[] headers = { "Column" };
+    String[][] lfData = {{ "line one\nline two" }};
+    String[][] crlfData = {{ "line one\r\nline two" }};
+
+    String crlfResult = FlipTable.of(headers, crlfData);
+    String lfResult = FlipTable.of(headers, lfData);
+
+    String expected = ""
+      + "╔══════════╗\n"
+      + "║ Column   ║\n"
+      + "╠══════════╣\n"
+      + "║ line one ║\n"
+      + "║ line two ║\n"
+      + "╚══════════╝\n";
+
+    assertThat(crlfResult).isEqualTo(lfResult);
+    assertThat(crlfResult).isEqualTo(expected);
+  }
 }


### PR DESCRIPTION
Fix for rendering of cells with line breaks on Windows using universal line break character `\R` instead of `\n` to split string by lines.
https://github.com/JakeWharton/flip-tables/issues/93