### PR TITLE
Prepare version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+## [1.1.2] - 2026-05-19
+
+ * Fix: Render cells containing CRLF (`\r\n`) line endings correctly.
+ * Build: Update Gradle to 9.5.1.
  * In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
 
 
@@ -32,7 +37,8 @@ Initial release.
 
 
 
-[Unreleased]: https://github.com/JakeWharton/flip-tables/compare/1.1.1...HEAD
+[Unreleased]: https://github.com/JakeWharton/flip-tables/compare/1.1.2...HEAD
+[1.1.2]: https://github.com/JakeWharton/flip-tables/releases/tag/1.1.2
 [1.1.1]: https://github.com/JakeWharton/flip-tables/releases/tag/1.1.1
 [1.1.0]: https://github.com/JakeWharton/flip-tables/releases/tag/1.1.0
 [1.0.2]: https://github.com/JakeWharton/flip-tables/releases/tag/1.0.2

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Download
 --------
 
 Download the [latest jar][1] or reference on Maven central as
-`com.jakewharton.fliptables:fliptables:1.1.1`.
+`com.jakewharton.fliptables:fliptables:1.1.2`.
 
 Snapshots of the development version are available in [the Central Portal Snapshots repository][snap].
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.jakewharton.fliptables
-VERSION_NAME=1.2.0-SNAPSHOT
+VERSION_NAME=1.1.2
 
 POM_ARTIFACT_ID=fliptables
 POM_NAME=Flip Tables


### PR DESCRIPTION
Prepares the 1.1.2 release per `RELEASING.md`:

- Bump `VERSION_NAME` in `gradle.properties` to `1.1.2`.
- Promote `Unreleased` to `[1.1.2] - 2026-05-19` in `CHANGELOG.md`, add new empty `Unreleased`, add reference link, update compare URL.
- Bump Maven coordinate in `README.md` Download section to `1.1.2`.

Changes captured in the 1.1.2 changelog entry:

- Fix: Render cells containing CRLF (`\r\n`) line endings correctly. (#94)
- Build: Update Gradle to 9.5.1. (#95, #96)
- Snapshots now publish to the Central Portal Snapshots repository. (#67)